### PR TITLE
Fix redmine #3566

### DIFF
--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -197,7 +197,8 @@ class API(base_api.NetworkAPI):
         """
         try:
             if fixed_ip:
-                port_req_body['port']['fixed_ips'] = [{'ip_address': fixed_ip}]
+                port_req_body['port']['fixed_ips'] = [
+                    {'ip_address': str(fixed_ip)}]
             port_req_body['port']['network_id'] = network_id
             port_req_body['port']['admin_state_up'] = True
             port_req_body['port']['tenant_id'] = instance['project_id']


### PR DESCRIPTION
If ip address is provided when running nova boot, nova compute
will invoke neutron client to create a port. However, the ip
address parameter is an IPAddress object so neutron client will
fail to send the request to neutron server. Transform IPAddress
object to string to address this issue.

Change-Id: I858cca475748795aa2532f32bfe0f1443b30966f
Closes-Bug: #1408529
