### PR TITLE
Redmine #3566 unittest

### DIFF
--- a/nova/tests/network/test_neutronv2.py
+++ b/nova/tests/network/test_neutronv2.py
@@ -494,8 +494,8 @@ class TestNeutronv2Base(test.TestCase):
             else:
                 request.address = fixed_ips.get(request.network_id)
                 if request.address:
-                    port_req_body['port']['fixed_ips'] = [{'ip_address':
-                                                           request.address}]
+                    port_req_body['port']['fixed_ips'] = [
+                        {'ip_address': str(request.address)}]
                 port_req_body['port']['network_id'] = request.network_id
                 port_req_body['port']['admin_state_up'] = True
                 port_req_body['port']['tenant_id'] = \


### PR DESCRIPTION
If ip address is provided when running nova boot, nova compute
will invoke neutron client to create a port. However, the ip
address parameter is an IPAddress object so neutron client will
fail to send the request to neutron server. Transform IPAddress
object to string to address this issue.

Change-Id: I858cca475748795aa2532f32bfe0f1443b30966f
Closes-Bug: #1408529
(cherry picked from commit aae858a246e20b1bf55004517b5d9ab28968190a)

Conflicts:
    nova/tests/unit/network/test_neutronv2.py

NOTE(apporc): Unittest change was not backported last time(790aeb3a60dcb3d299c806ffea14e4df6c21a81b), it's a mistake.
