### PR TITLE
fix redmine #4122

### DIFF
--- a/nova/compute/flavors.py
+++ b/nova/compute/flavors.py
@@ -71,7 +71,7 @@ def _int_or_none(val):
 
 system_metadata_flavor_props = {
     'id': int,
-    'name': str,
+    'name': unicode,
     'memory_mb': int,
     'vcpus': int,
     'root_gb': int,


### PR DESCRIPTION
non-ascii flavor name breaks nova.

Signed-off-by: apporc appleorchard2000@gmail.com
