### PR TITLE
fix redmine #4544

### DIFF
--- a/nova/virt/libvirt/host.py
+++ b/nova/virt/libvirt/host.py
@@ -30,7 +30,10 @@ the other libvirt related classes
 from oslo.utils import importutils
 from nova.openstack.common import log as logging
 
-libvirt = importutils.import_module('libvirt')
+try:
+    libvirt = importutils.import_module('libvirt')
+except ImportError:
+    libvirt = None
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
By default there is no libvirt module on controllers node, we
should catch the error. Services on controllers don't really
use this host module, so we can just ignore the ImportError.

Signed-off-by: apporc appleorchard2000@gmail.com
