### PR TITLE
Honor shared storage on resize revert

### DIFF
--- a/nova/compute/rpcapi.py
+++ b/nova/compute/rpcapi.py
@@ -368,13 +368,13 @@ class ComputeAPI(object):
                           instance=instance,
                           dest_check_data=dest_check_data)
 
-    def check_instance_shared_storage(self, ctxt, instance, data):
+    def check_instance_shared_storage(self, ctxt, instance, data, host=None):
         if self.client.can_send_version('3.29'):
             version = '3.29'
         else:
             version = '3.0'
             instance = jsonutils.to_primitive(instance)
-        cctxt = self.client.prepare(server=_compute_host(None, instance),
+        cctxt = self.client.prepare(server=_compute_host(host, instance),
                 version=version)
         return cctxt.call(ctxt, 'check_instance_shared_storage',
                           instance=instance,

--- a/nova/tests/compute/test_compute.py
+++ b/nova/tests/compute/test_compute.py
@@ -4266,6 +4266,8 @@ class ComputeTestCase(BaseTestCase):
             self.context, objects.Instance(), instance,
             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS)
         for operation in actions:
+            if 'revert_resize' in operation:
+                migration.source_compute = 'fake-mini'
             if operation[0] in want_objects:
                 self._test_state_revert(inst_obj, *operation)
             else:
@@ -6610,7 +6612,7 @@ class ComputeTestCase(BaseTestCase):
                 evacuated_instance).AndReturn({'filename': 'tmpfilename'})
         self.compute.compute_rpcapi.check_instance_shared_storage(fake_context,
                 evacuated_instance,
-                {'filename': 'tmpfilename'}).AndReturn(False)
+                {'filename': 'tmpfilename'}, host=None).AndReturn(False)
         self.compute.driver.check_instance_shared_storage_cleanup(fake_context,
                 {'filename': 'tmpfilename'})
         self.compute.driver.destroy(fake_context, evacuated_instance,

--- a/nova/tests/compute/test_compute_mgr.py
+++ b/nova/tests/compute/test_compute_mgr.py
@@ -3060,3 +3060,67 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase):
             )
             self.assertEqual("error", self.migration.status)
             migration_save.assert_has_calls([mock.call(elevated_context)])
+
+    @mock.patch.object(objects.InstanceActionEvent,
+                       'event_start')
+    @mock.patch.object(objects.InstanceActionEvent,
+                       'event_finish_with_failure')
+    def _test_revert_resize_instance_destroy_disks(self,
+                                                   event_finish,
+                                                   event_start,
+                                                   is_shared=False,):
+
+        # This test asserts that _is_instance_storage_shared() is called from
+        # revert_resize() and the return value is passed to driver.destroy().
+        # Otherwise we could regress this.
+
+        @mock.patch.object(self.compute, '_get_instance_nw_info')
+        @mock.patch.object(self.compute, '_is_instance_storage_shared')
+        @mock.patch.object(self.compute, 'finish_revert_resize')
+        @mock.patch.object(self.compute, '_instance_update')
+        @mock.patch.object(self.compute, '_get_resource_tracker')
+        @mock.patch.object(self.compute.driver, 'destroy')
+        @mock.patch.object(self.compute.network_api, 'setup_networks_on_host')
+        @mock.patch.object(self.compute.network_api, 'migrate_instance_start')
+        @mock.patch.object(self.compute.conductor_api, 'notify_usage_exists')
+        @mock.patch.object(self.migration, 'save')
+        @mock.patch.object(objects.BlockDeviceMappingList,
+                           'get_by_instance_uuid')
+        def do_test(get_by_instance_uuid,
+                    migration_save,
+                    notify_usage_exists,
+                    migrate_instance_start,
+                    setup_networks_on_host,
+                    destroy,
+                    _get_resource_tracker,
+                    _instance_update,
+                    finish_revert_resize,
+                    _is_instance_storage_shared,
+                    _get_instance_nw_info):
+
+            self.migration.source_compute = self.instance['host']
+
+            # Inform compute that instance uses non-shared or shared storage
+            _is_instance_storage_shared.return_value = is_shared
+
+            self.compute.revert_resize(context=self.context,
+                                       migration=self.migration,
+                                       instance=self.instance,
+                                       reservations=None)
+
+            _is_instance_storage_shared.assert_called_once_with(
+                self.context, self.instance,
+                host=self.migration.source_compute)
+
+            # If instance storage is shared, driver destroy method
+            # should not destroy disks otherwise it should destroy disks.
+            destroy.assert_called_once_with(self.context, self.instance,
+                                            mock.ANY, mock.ANY, not is_shared)
+
+        do_test()
+
+    def test_revert_resize_instance_destroy_disks_shared_storage(self):
+        self._test_revert_resize_instance_destroy_disks(is_shared=True)
+
+    def test_revert_resize_instance_destroy_disks_non_shared_storage(self):
+        self._test_revert_resize_instance_destroy_disks(is_shared=False)


### PR DESCRIPTION
This patch improves the logic in resize_revert() to properly honor
shared storage when destroying the unneeded instance.  In the case of
shared storage, the disks need not be destroyed and doing so results in
the inability to start the original instance.

Conflicts is caused by moving tests to /unit directory

Also commit contains squash from fixed implementation of determening
if storage is shared (get from commit fde77d49ff550b73f5f1671edc7366c9b7646200)

Conflicts:
        nova/tests/unit/compute/test_compute.py
        nova/tests/unit/compute/test_compute_mgr.py

Closes-Bug: #1399244
Change-Id: I310f6b62a790e4549a2cf9ff3842655da552177a
(cherry picked from commit eec0937af9d88f3c7ffacf9ce7b8955b2e4be479)
(cherry picked from commit b6692dd9f619de932ea9fc356da41ee1b471114c)

NOTE(apporc): revert changes of 731e9200ed91a6122b3b71e7ac01be9bbc54b2fa.

 Conflicts:
    nova/compute/manager.py
