### PR TITLE
get instance object from compute api

### DIFF
--- a/nova/api/openstack/compute/contrib/floating_ips.py
+++ b/nova/api/openstack/compute/contrib/floating_ips.py
@@ -86,7 +86,7 @@ def get_instance_by_floating_ip_addr(self, context, address):
     snagiibfa = self.network_api.get_instance_id_by_floating_address
     instance_id = snagiibfa(context, address)
     if instance_id:
-        return self.compute_api.get(context, instance_id)
+        return self.compute_api.get(context, instance_id, want_objects=True)
 
 
 def disassociate_floating_ip(self, context, instance, address):
@@ -206,7 +206,8 @@ class FloatingIPActionController(wsgi.Controller):
             msg = _("Address not specified")
             raise webob.exc.HTTPBadRequest(explanation=msg)
 
-        instance = common.get_instance(self.compute_api, context, id)
+        instance = common.get_instance(self.compute_api, context, id,
+                                       want_objects=True)
         cached_nwinfo = compute_utils.get_nw_info_for_instance(instance)
         if not cached_nwinfo:
             msg = _('No nw_info cache associated with instance')


### PR DESCRIPTION
Fix instance has no attribute 'info_cache' issue when
associate/disassociate floating ip.

Fix redmine #10873

Signed-off-by: blkart <blkart.org@gmail.com>
(cherry picked from commit 50d80038cd6cf30245293d05271b0218f2d5e614)